### PR TITLE
added wording to clarify that IntelliJ should be used for pushing

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,9 @@ a sequence of three git commands:
    You can put whatever message you want in the quotes, but try to keep it short and descriptive.
 3. `git push`
    - this last step is what actually sends your committed changes to your remote GitHub repository.
+   - IMPORTANT: You likely won't have your system configured for this command to actually work directly, so you
+   will most likely need to do the actual push using IntelliJ. See the first tip below, which mentions how to perform
+   the relevant git operations through IntelliJ's graphical user interface.
 
 - [ ] Once you execute these commands, you can check your GitHub repository to confirm that the changes have been made there.
 
@@ -219,7 +222,11 @@ From that you can select `Commit...`, which will allow you to add and commit fil
 indicate which files to add and put the commit message in the textbox, then press the commit button).
 That menu also gives you the option to commit and push in one step if you wish to do so.
 If you chose to only commit, then you can later go back to the `Git` menu and choose `Push...` to open a
-menu to then push your commits to your remote GitHub repository.
+menu to then push your commits to your remote GitHub repository. When you try to push, you will be prompted
+to provide a GitHub access Token to authenticate if you haven't already added one. There will be a `Generate...`
+button in the popup. Clicking that will take you to a GitHub page which will generate the token for you. Once
+you generate the token, you copy it into the dialog box in IntelliJ and the push should go through. If you
+have trouble with this, please ask and someone around can help you through the steps.
 
 Tip: It is good practice to get in the habit of making commits that are small and have a distinct purpose.
 For example, one might imagine making a commit each time they complete a task they are working on or finish


### PR DESCRIPTION
A common issue in labs was that `git push` would not work, since username-password authentication is no longer supported.

The readme has been updated to *attempt* to clarify the required steps to use IntelliJ to push the code instead of using `git push` from the Terminal.